### PR TITLE
feat: toggle auth links in header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,46 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from './context/ThemeContext';
+import { AuthProvider } from './context/AuthContext';
 import Header from './components/Header';
 import Home from './pages/Home';
 import REXDetail from './pages/REXDetail';
 import CreateREX from './pages/CreateREX';
 import Tags from './pages/Tags';
 import Profile from './pages/Profile';
+import Login from './pages/Login';
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
-    <ThemeProvider>
-      <Router>
-        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors">
-          <Header />
-          <main>
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/rex/:id" element={<REXDetail />} />
-              <Route path="/create" element={<CreateREX />} />
-              <Route path="/tags" element={<Tags />} />
-              <Route path="/tags/:tag" element={<Home />} />
-              <Route path="/profile" element={<Profile />} />
-              <Route path="/profile/:id" element={<Profile />} />
-            </Routes>
-          </main>
-        </div>
-      </Router>
-    </ThemeProvider>
+    <AuthProvider>
+      <ThemeProvider>
+        <Router>
+          <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors">
+            <Header />
+            <main>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/rex/:id" element={<REXDetail />} />
+                <Route
+                  path="/create"
+                  element={
+                    <ProtectedRoute>
+                      <CreateREX />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route path="/tags" element={<Tags />} />
+                <Route path="/tags/:tag" element={<Home />} />
+                <Route path="/profile" element={<Profile />} />
+                <Route path="/profile/:id" element={<Profile />} />
+                <Route path="/login" element={<Login />} />
+              </Routes>
+            </main>
+          </div>
+        </Router>
+      </ThemeProvider>
+    </AuthProvider>
   );
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Search, Moon, Sun, Menu, X, Plus, User } from 'lucide-react';
+import { Moon, Sun, Menu, X, Plus, User } from 'lucide-react';
 import { useTheme } from '../context/ThemeContext';
+import { useAuth } from '../context/AuthContext';
 
 const Header: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
+  const { isAuthenticated, logout } = useAuth();
   const location = useLocation();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
 
   const isActive = (path: string) => location.pathname === path;
 
@@ -41,7 +44,7 @@ const Header: React.FC = () => {
               Tags
             </Link>
             <Link
-              to="/create"
+              to={isAuthenticated ? '/create' : '/login'}
               className="inline-flex items-center space-x-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
             >
               <Plus className="w-4 h-4" />
@@ -58,13 +61,52 @@ const Header: React.FC = () => {
             >
               {theme === 'light' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
             </button>
-            
-            <Link
-              to="/profile"
-              className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
-            >
-              <User className="w-5 h-5" />
-            </Link>
+
+            {isAuthenticated ? (
+              <div className="relative">
+                <button
+                  onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
+                  className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+                >
+                  <User className="w-5 h-5" />
+                </button>
+                {isUserMenuOpen && (
+                  <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg py-1">
+                    <Link
+                      to="/profile"
+                      className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      onClick={() => setIsUserMenuOpen(false)}
+                    >
+                      Profil
+                    </Link>
+                    <button
+                      onClick={() => {
+                        logout();
+                        setIsUserMenuOpen(false);
+                      }}
+                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    >
+                      Se déconnecter
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="flex items-center space-x-2">
+                <Link
+                  to="/login"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"
+                >
+                  Login
+                </Link>
+                <Link
+                  to="/login?register=true"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"
+                >
+                  Inscription
+                </Link>
+              </div>
+            )}
 
             {/* Mobile menu button */}
             <button
@@ -99,13 +141,50 @@ const Header: React.FC = () => {
                 Tags
               </Link>
               <Link
-                to="/create"
+                to={isAuthenticated ? '/create' : '/login'}
                 className="inline-flex items-center space-x-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors w-fit"
                 onClick={() => setIsMobileMenuOpen(false)}
               >
                 <Plus className="w-4 h-4" />
                 <span>Créer un REX</span>
               </Link>
+              {isAuthenticated ? (
+                <>
+                  <Link
+                    to="/profile"
+                    className="text-sm font-medium transition-colors hover:text-blue-600 dark:hover:text-blue-400 text-gray-700 dark:text-gray-300"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    Profil
+                  </Link>
+                  <button
+                    onClick={() => {
+                      logout();
+                      setIsMobileMenuOpen(false);
+                    }}
+                    className="text-sm font-medium text-left text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"
+                  >
+                    Se déconnecter
+                  </button>
+                </>
+              ) : (
+                <>
+                  <Link
+                    to="/login"
+                    className="text-sm font-medium transition-colors hover:text-blue-600 dark:hover:text-blue-400 text-gray-700 dark:text-gray-300"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    Login
+                  </Link>
+                  <Link
+                    to="/login?register=true"
+                    className="text-sm font-medium transition-colors hover:text-blue-600 dark:hover:text-blue-400 text-gray-700 dark:text-gray-300"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    Inscription
+                  </Link>
+                </>
+              )}
             </nav>
           </div>
         )}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+interface Props {
+  children: JSX.Element;
+}
+
+const ProtectedRoute: React.FC<Props> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;
+

--- a/src/components/REXCard.tsx
+++ b/src/components/REXCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Calendar, MessageCircle, ThumbsUp, ThumbsDown, User } from 'lucide-react';
+import { Calendar, MessageCircle, ThumbsUp, ThumbsDown } from 'lucide-react';
 import { REX } from '../types';
 
 interface REXCardProps {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => {
+    return localStorage.getItem('isAuthenticated') === 'true';
+  });
+
+  const login = () => {
+    setIsAuthenticated(true);
+    localStorage.setItem('isAuthenticated', 'true');
+  };
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    localStorage.removeItem('isAuthenticated');
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,16 @@
 import React, { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { TrendingUp, Users, BookOpen, Award } from 'lucide-react';
 import REXCard from '../components/REXCard';
 import SearchAndFilters from '../components/SearchAndFilters';
 import { mockREX, mockTags } from '../data/mockData';
+import { useAuth } from '../context/AuthContext';
 
 const Home: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedComplexity, setSelectedComplexity] = useState('');
+  const { isAuthenticated } = useAuth();
 
   const filteredREX = useMemo(() => {
     return mockREX.filter((rex) => {
@@ -118,12 +121,12 @@ const Home: React.FC = () => {
           <p className="text-gray-600 dark:text-gray-300 mb-6 max-w-2xl mx-auto">
             Vous avez vécu une expérience technique intéressante ? Aidez la communauté en partageant votre retour d'expérience.
           </p>
-          <a
-            href="/create"
+          <Link
+            to={isAuthenticated ? '/create' : '/login'}
             className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-medium rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-200 shadow-lg hover:shadow-xl"
           >
             Créer mon premier REX
-          </a>
+          </Link>
         </div>
       )}
     </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation, Location, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const Login: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [isRegistering, setIsRegistering] = useState(searchParams.get('register') === 'true');
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: Location })?.from?.pathname || '/';
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    login();
+    navigate(from, { replace: true });
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="w-full max-w-md p-8 bg-white dark:bg-gray-800 rounded-lg shadow">
+        <h1 className="text-2xl font-bold mb-6 text-center text-gray-900 dark:text-white">
+          {isRegistering ? 'Inscription' : 'Connexion'}
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Mot de passe"
+            className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white"
+            required
+          />
+          {isRegistering && (
+            <input
+              type="password"
+              placeholder="Confirmez le mot de passe"
+              className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white"
+              required
+            />
+          )}
+          <button
+            type="submit"
+            className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
+          >
+            {isRegistering ? "S'inscrire" : 'Se connecter'}
+          </button>
+        </form>
+        <div className="mt-4 text-center">
+          {isRegistering ? (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Vous avez déjà un compte ?{' '}
+              <button
+                type="button"
+                onClick={() => {
+                  setIsRegistering(false);
+                  setSearchParams({});
+                }}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Se connecter
+              </button>
+            </p>
+          ) : (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Nouveau sur Rex IT ?{' '}
+              <button
+                type="button"
+                onClick={() => {
+                  setIsRegistering(true);
+                  setSearchParams({ register: 'true' });
+                }}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Créer un compte
+              </button>
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;
+

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -3,11 +3,13 @@ import { Calendar, MapPin, Link as LinkIcon, Award, BookOpen, ThumbsUp } from 'l
 import { Link } from 'react-router-dom';
 import REXCard from '../components/REXCard';
 import { mockUsers, mockREX } from '../data/mockData';
+import { useAuth } from '../context/AuthContext';
 
 const Profile: React.FC = () => {
   // Using first user as current user for demo
   const user = mockUsers[0];
   const userREX = mockREX.filter(rex => rex.author.id === user.id);
+  const { isAuthenticated } = useAuth();
   
   const stats = [
     { icon: BookOpen, label: 'REX Publiés', value: userREX.length },
@@ -62,7 +64,7 @@ const Profile: React.FC = () => {
           {/* Action Button */}
           <div className="flex-shrink-0">
             <Link
-              to="/create"
+              to={isAuthenticated ? '/create' : '/login'}
               className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
             >
               Nouveau REX
@@ -93,7 +95,7 @@ const Profile: React.FC = () => {
           </h2>
           {userREX.length === 0 && (
             <Link
-              to="/create"
+              to={isAuthenticated ? '/create' : '/login'}
               className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
             >
               Créer mon premier REX
@@ -111,7 +113,7 @@ const Profile: React.FC = () => {
               Partagez votre première expérience technique avec la communauté.
             </p>
             <Link
-              to="/create"
+              to={isAuthenticated ? '/create' : '/login'}
               className="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
             >
               Créer mon premier REX

--- a/src/pages/REXDetail.tsx
+++ b/src/pages/REXDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, Calendar, User, Hash, Award, Share2 } from 'lucide-react';
+import { ArrowLeft, Calendar, Hash, Award, Share2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { mockREX, mockComments } from '../data/mockData';
 import VotingSystem from '../components/VotingSystem';

--- a/src/pages/Tags.tsx
+++ b/src/pages/Tags.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Hash, TrendingUp, Users } from 'lucide-react';
 import { mockTags } from '../data/mockData';
+import { useAuth } from '../context/AuthContext';
 
 const Tags: React.FC = () => {
   const sortedTags = [...mockTags].sort((a, b) => b.count - a.count);
+  const { isAuthenticated } = useAuth();
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -88,7 +90,7 @@ const Tags: React.FC = () => {
           Les tags sont créés automatiquement selon vos contributions.
         </p>
         <Link
-          to="/create"
+          to={isAuthenticated ? '/create' : '/login'}
           className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-medium rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-200 shadow-lg hover:shadow-xl"
         >
           Créer un REX


### PR DESCRIPTION
## Summary
- show login and registration links for unauthenticated visitors
- display user menu with logout option when authenticated
- allow direct signup via query param on login page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b46a4354f48326ba198bb2db086178