### PR TITLE
Use type-only Location import in Login

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
-import { useNavigate, useLocation, Location, useSearchParams } from 'react-router-dom';
+import { useNavigate, useLocation, useSearchParams, type Location } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+
 const Login: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [isRegistering, setIsRegistering] = useState(searchParams.get('register') === 'true');
-import { useNavigate, useLocation, Location } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
-const Login: React.FC = () => {
-  const [isRegistering, setIsRegistering] = useState(false);
   const { login } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -63,7 +60,6 @@ const Login: React.FC = () => {
                   setIsRegistering(false);
                   setSearchParams({});
                 }}
-                onClick={() => setIsRegistering(false)}
                 className="text-blue-600 dark:text-blue-400 hover:underline"
               >
                 Se connecter
@@ -78,7 +74,6 @@ const Login: React.FC = () => {
                   setIsRegistering(true);
                   setSearchParams({ register: 'true' });
                 }}
-                onClick={() => setIsRegistering(true)}
                 className="text-blue-600 dark:text-blue-400 hover:underline"
               >
                 Créer un compte


### PR DESCRIPTION
## Summary
- import `Location` as a type in `Login.tsx`
- clean up login component import and state initialization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b475c58a1c8326859fcb41f10216d6