### PR TITLE
refactor: move hosting directives to root

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -14,14 +14,16 @@ frontend:
   cache:
     paths:
       - node_modules/**/*
-  # ✅ Configuration cruciale pour les SPA React
-  customHeaders:
-    - pattern: '**/*'
-      headers:
-        - key: 'Cache-Control'
-          value: 'no-cache'
-  # ✅ Redirections pour SPA
-  redirects:
-    - source: '/<*>'
-      target: '/index.html'
-      status: '200'
+
+# ✅ Configuration cruciale pour les SPA React
+customHeaders:
+  - pattern: '**/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'no-cache'
+
+# ✅ Redirections pour SPA
+redirects:
+  - source: '/<*>'
+    target: '/index.html'
+    status: '200'


### PR DESCRIPTION
## Summary
- move `customHeaders` and `redirects` to root in `amplify.yml`

## Testing
- `npm run lint`
- `npm run build` *(fails: The symbol "isAuthenticated" has already been declared in src/components/Header.tsx)*
- `npx yaml-lint amplify.yml` *(fails: 403 Forbidden to fetch yaml-lint)*

------
https://chatgpt.com/codex/tasks/task_e_68b47a9902148326af8f935d4a102dbf